### PR TITLE
Debug society creation registration error

### DIFF
--- a/Housing_Management_System/src/main/java/com/app/dao/SocietyDao.java
+++ b/Housing_Management_System/src/main/java/com/app/dao/SocietyDao.java
@@ -11,6 +11,8 @@ import com.app.model.Society;
 public interface SocietyDao extends JpaRepository<Society, Long> {
     
     boolean existsByName(String name);
+
+    boolean existsByRegistrationNumber(String registrationNumber);
     
     Optional<Society> findByName(String name);
 }

--- a/Housing_Management_System/src/main/java/com/app/dto/SocietyCreationRequest.java
+++ b/Housing_Management_System/src/main/java/com/app/dto/SocietyCreationRequest.java
@@ -19,6 +19,20 @@ public class SocietyCreationRequest {
     @NotBlank(message = "Society address is required")
     @Size(min = 5, max = 255, message = "Society address must be between 5 and 255 characters")
     private String address;
+
+    @NotBlank(message = "Registration number is required")
+    @Size(min = 3, max = 50, message = "Registration number must be between 3 and 50 characters")
+    private String registrationNumber;
+
+    @NotBlank(message = "City is required")
+    private String city;
+
+    @NotBlank(message = "State is required")
+    private String state;
+
+    @NotBlank(message = "Pincode is required")
+    @Pattern(regexp = "^[0-9]{6}$", message = "Pincode must be 6 digits")
+    private String pincode;
     
     @Min(value = 1, message = "Number of buildings must be at least 1")
     private Integer numberOfBuildings;

--- a/Housing_Management_System/src/main/java/com/app/dto/SocietyDTO.java
+++ b/Housing_Management_System/src/main/java/com/app/dto/SocietyDTO.java
@@ -18,6 +18,18 @@ public class SocietyDTO {
     
     @NotBlank(message = "Address is required")
     private String address;
+
+    @NotBlank(message = "Registration number is required")
+    private String registrationNumber;
+
+    @NotBlank(message = "City is required")
+    private String city;
+
+    @NotBlank(message = "State is required")
+    private String state;
+
+    @NotBlank(message = "Pincode is required")
+    private String pincode;
     
     @Min(value = 1, message = "Number of buildings must be at least 1")
     private Integer numberOfBuildings;

--- a/Housing_Management_System/src/main/java/com/app/model/Society.java
+++ b/Housing_Management_System/src/main/java/com/app/model/Society.java
@@ -26,6 +26,18 @@ public class Society {
     @Column(nullable = false)
     private String address;
     
+    @Column(name = "registration_number", nullable = false, unique = true)
+    private String registrationNumber;
+    
+    @Column(nullable = false)
+    private String city;
+    
+    @Column(nullable = false)
+    private String state;
+    
+    @Column(length = 10, nullable = false)
+    private String pincode;
+    
     @Column(name = "number_of_buildings")
     private Integer numberOfBuildings;
     

--- a/Housing_Management_System/src/main/java/com/app/service/SocietyServiceImpl.java
+++ b/Housing_Management_System/src/main/java/com/app/service/SocietyServiceImpl.java
@@ -49,10 +49,17 @@ public class SocietyServiceImpl implements SocietyService {
         if (societyRepository.existsByName(request.getName())) {
             throw new ResourceAlreadyExistsException("Society already exists with name: " + request.getName());
         }
+        if (societyRepository.existsByRegistrationNumber(request.getRegistrationNumber())) {
+            throw new ResourceAlreadyExistsException("Society already exists with registration number: " + request.getRegistrationNumber());
+        }
 
         Society society = Society.builder()
                 .name(request.getName())
                 .address(request.getAddress())
+                .registrationNumber(request.getRegistrationNumber())
+                .city(request.getCity())
+                .state(request.getState())
+                .pincode(request.getPincode())
                 .numberOfBuildings(request.getNumberOfBuildings())
                 .build();
 


### PR DESCRIPTION
Add missing society details and validation to DTOs and entity to resolve `SQLException: Field 'registration_number' doesn't have a default value`.

The `societies` database table expected `registration_number`, `city`, `state`, and `pincode` to be non-null, but these fields were not present in the `SocietyCreationRequest` DTO or `Society` entity, causing a `java.sql.SQLException` during society creation. This PR synchronizes the application's data models with the database schema and adds a uniqueness check for the registration number.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd5852bf-d948-4784-b67e-aef9a194001d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd5852bf-d948-4784-b67e-aef9a194001d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>